### PR TITLE
fix roleType converter and add tests

### DIFF
--- a/sdk/communication/azure-communication-rooms/src/main/java/com/azure/communication/rooms/implementation/converters/RoleTypeConverter.java
+++ b/sdk/communication/azure-communication-rooms/src/main/java/com/azure/communication/rooms/implementation/converters/RoleTypeConverter.java
@@ -21,13 +21,13 @@ public final class RoleTypeConverter {
         RoleType role = RoleType.ATTENDEE;
 
         switch (roleType.toString()) {
-            case "ATTENDEE":
+            case "Attendee":
                 role = RoleType.ATTENDEE;
                 break;
-            case "CONSUMER":
+            case "Consumer":
                 role = RoleType.CONSUMER;
                 break;
-            case "PRESENTER":
+            case "Presenter":
                 role = RoleType.PRESENTER;
                 break;
             default:
@@ -48,13 +48,13 @@ public final class RoleTypeConverter {
         com.azure.communication.rooms.implementation.models.RoleType role = com.azure.communication.rooms.implementation.models.RoleType.ATTENDEE;
 
         switch (roleType.toString()) {
-            case "ATTENDEE":
+            case "Attendee":
                 role = com.azure.communication.rooms.implementation.models.RoleType.ATTENDEE;
                 break;
-            case "CONSUMER":
+            case "Consumer":
                 role = com.azure.communication.rooms.implementation.models.RoleType.CONSUMER;
                 break;
-            case "PRESENTER":
+            case "Presenter":
                 role = com.azure.communication.rooms.implementation.models.RoleType.PRESENTER;
                 break;
             default:

--- a/sdk/communication/azure-communication-rooms/src/test/java/com/azure/communication/rooms/RoomsAsyncClientTests.java
+++ b/sdk/communication/azure-communication-rooms/src/test/java/com/azure/communication/rooms/RoomsAsyncClientTests.java
@@ -7,10 +7,12 @@ import java.util.ArrayList;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.stream.IntStream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.azure.communication.rooms.models.*;
 import com.azure.core.http.HttpClient;
@@ -42,12 +44,12 @@ public class RoomsAsyncClientTests extends RoomsTestBase {
         roomsAsyncClient = setupAsyncClient(httpClient, "createRoomFullCycleWithResponse");
         assertNotNull(roomsAsyncClient);
         Mono<Response<CommunicationRoom>> response1 = roomsAsyncClient.createRoomWithResponse(VALID_FROM, VALID_UNTIL, roomJoinPolicy, participants1);
-        
+
         List<String> roomParticipantsMri = new ArrayList<String>();
         roomParticipantsMri.add(participants1.get(0).getCommunicationIdentifier().getRawId());
         roomParticipantsMri.add(participants1.get(1).getCommunicationIdentifier().getRawId());
         roomParticipantsMri.add(participants1.get(2).getCommunicationIdentifier().getRawId());
-        
+
         StepVerifier.create(response1)
             .assertNext(roomResult -> {
                 assertHappyPath(roomResult, 201);
@@ -63,7 +65,7 @@ public class RoomsAsyncClientTests extends RoomsTestBase {
         Mono<Response<CommunicationRoom>> response3 =  roomsAsyncClient.updateRoomWithResponse(roomId, VALID_FROM, VALID_FROM.plusMonths(3), null, null);
 
         System.out.println(VALID_FROM.plusMonths(3).getDayOfYear());
-        
+
         StepVerifier.create(response3)
             .assertNext(roomResult -> {
                 assertHappyPath(roomResult, 200);
@@ -92,9 +94,12 @@ public class RoomsAsyncClientTests extends RoomsTestBase {
         Mono<CommunicationRoom> response1 = roomsAsyncClient.createRoom(VALID_FROM, VALID_UNTIL, roomJoinPolicy, participants1);
 
         StepVerifier.create(response1)
-          .assertNext(roomResult -> {
-              assertEquals(roomResult.getParticipants().size(), 3);
-          }).verifyComplete();
+            .assertNext(roomResult -> {
+                List<RoomParticipant> returnedParticipants = roomResult.getParticipants();
+                assertEquals(participants1.size(), returnedParticipants.size());
+                IntStream.range(0, returnedParticipants.size())
+                    .forEach(x -> assertTrue(areParticipantsEqual(participants1.get(x), returnedParticipants.get(x))));
+            }).verifyComplete();
 
         String roomId = response1.block().getRoomId();
 
@@ -172,7 +177,10 @@ public class RoomsAsyncClientTests extends RoomsTestBase {
         StepVerifier.create(response2)
             .assertNext(result2 -> {
                 assertEquals(result2.getStatusCode(), 200);
-                assertEquals(result2.getValue().getParticipants().size(), 3);
+                List<RoomParticipant> returnedParticipants = result2.getValue().getParticipants();
+                assertEquals(participants5.size(), returnedParticipants.size());
+                IntStream.range(0, returnedParticipants.size())
+                    .forEach(x -> assertTrue(areParticipantsEqual(participants5.get(x), returnedParticipants.get(x))));
             }).verifyComplete();
     }
 
@@ -195,7 +203,10 @@ public class RoomsAsyncClientTests extends RoomsTestBase {
 
         StepVerifier.create(response2)
             .assertNext(roomResult -> {
-                assertEquals(roomResult.getParticipants().size(), 3);
+                List<RoomParticipant> returnedParticipants = roomResult.getParticipants();
+                assertEquals(participants5.size(), returnedParticipants.size());
+                IntStream.range(0, returnedParticipants.size())
+                    .forEach(x -> assertTrue(areParticipantsEqual(participants5.get(x), returnedParticipants.get(x))));
             }).verifyComplete();
 
         StepVerifier.create(roomsAsyncClient.getRoom(roomId)).assertNext(response4 -> {
@@ -224,7 +235,10 @@ public class RoomsAsyncClientTests extends RoomsTestBase {
         StepVerifier.create(response2)
             .assertNext(result2 -> {
                 assertEquals(result2.getStatusCode(), 200);
-                assertEquals(result2.getValue().getParticipants().size(), 2);
+                List<RoomParticipant> returnedParticipants = result2.getValue().getParticipants();
+                assertEquals(2, returnedParticipants.size());
+                assertTrue(areParticipantsEqual(firstChangeParticipant, returnedParticipants.get(0)));
+                assertTrue(areParticipantsEqual(secondParticipant, returnedParticipants.get(1)));
             }).verifyComplete();
     }
 
@@ -246,6 +260,9 @@ public class RoomsAsyncClientTests extends RoomsTestBase {
         StepVerifier.create(response2)
             .assertNext(roomResult -> {
                 assertEquals(roomResult.getParticipants().size(), 2);
+                List<RoomParticipant> returnedParticipants = roomResult.getParticipants();
+                assertTrue(areParticipantsEqual(firstChangeParticipant, returnedParticipants.get(0)));
+                assertTrue(areParticipantsEqual(secondParticipant, returnedParticipants.get(1)));
             }).verifyComplete();
     }
 

--- a/sdk/communication/azure-communication-rooms/src/test/java/com/azure/communication/rooms/RoomsClientTest.java
+++ b/sdk/communication/azure-communication-rooms/src/test/java/com/azure/communication/rooms/RoomsClientTest.java
@@ -14,8 +14,11 @@ import org.junit.jupiter.params.provider.MethodSource;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Collections;
+import java.util.List;
+import java.util.stream.IntStream;
 
 public class RoomsClientTest extends RoomsTestBase {
     private RoomsClient roomsClient;
@@ -499,9 +502,12 @@ public class RoomsClientTest extends RoomsTestBase {
         roomsClient = setupSyncClient(httpClient, "createRoomSyncWithReponseOnlyParticipants");
         assertNotNull(roomsClient);
 
-        Response<CommunicationRoom> createCommunicationRoom = roomsClient.createRoomWithResponse(null, null, null, participants4, Context.NONE);
+        Response<CommunicationRoom> createCommunicationRoom = roomsClient.createRoomWithResponse(null, null, null, participants6, Context.NONE);
         assertHappyPath(createCommunicationRoom, 201);
-        assertEquals(createCommunicationRoom.getValue().getParticipants().size(), 2);
+        List<RoomParticipant> returnedParticipants = createCommunicationRoom.getValue().getParticipants();
+        assertEquals(participants6.size(), returnedParticipants.size());
+        IntStream.range(0, returnedParticipants.size())
+            .forEach(x -> assertTrue(areParticipantsEqual(participants6.get(x), returnedParticipants.get(x))));
         String roomId = createCommunicationRoom.getValue().getRoomId();
 
         Response<Void> deleteResponse = roomsClient.deleteRoomWithResponse(roomId, Context.NONE);

--- a/sdk/communication/azure-communication-rooms/src/test/java/com/azure/communication/rooms/RoomsTestBase.java
+++ b/sdk/communication/azure-communication-rooms/src/test/java/com/azure/communication/rooms/RoomsTestBase.java
@@ -238,4 +238,9 @@ public class RoomsTestBase extends TestBase {
         }
         return content;
     }
+
+    protected boolean areParticipantsEqual(RoomParticipant participant1, RoomParticipant participant2) {
+        return participant1.getCommunicationIdentifier().getRawId().equals(participant1.getCommunicationIdentifier().getRawId())
+            && participant1.getRole().toString().equals(participant2.getRole().toString());
+    }
 }


### PR DESCRIPTION
# Description

[Please add an informative description that covers that changes made by the pull request and link all relevant issues.](https://skype.visualstudio.com/SPOOL/_workitems/edit/2933993)

All role types will be converted to Attendee because the switch block in roletype converter has a case mismatch. Fixed the bug and added test coverage

If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.

# All SDK Contribution checklist:
- [x ] **The pull request does not introduce [breaking changes]**
- [x ] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-java/blob/main/CONTRIBUTING.md).**

## [General Guidelines and Best Practices](https://github.com/Azure/azure-sdk-for-java/blob/main/CONTRIBUTING.md#developer-guide)
- [x ] Title of the pull request is clear and informative.
- [x ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-java/blob/main/CONTRIBUTING.md#building-and-unit-testing)
- [ x] Pull request includes test coverage for the included changes.
